### PR TITLE
Provide `IntoId` trait for ID extraction

### DIFF
--- a/examples/create.rs
+++ b/examples/create.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ethanol = model
         .build_species("ethanol")
         .name("Ethanol")
-        .compartment(&compartment.id())
+        .compartment(&compartment)
         .initial_concentration(0.5)
         .unit(&mole.id())
         .has_only_substance_units(false)
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let aldehyde = model
         .build_species("aldehyde")
         .name("Aldehyde")
-        .compartment(&compartment.id())
+        .compartment(&compartment)
         .initial_concentration(0.5)
         .unit(&mole.id())
         .has_only_substance_units(false)
@@ -48,8 +48,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     model
         .build_reaction("reaction")
         .name("Reaction")
-        .reactant(&ethanol.id(), 1.0)
-        .product(&aldehyde.id(), 1.0)
+        .reactant(&ethanol, 1.0)
+        .product(&aldehyde, 1.0)
         .build();
 
     // Serialize the document to an SBML string

--- a/src/compartment.rs
+++ b/src/compartment.rs
@@ -12,7 +12,7 @@ use std::{cell::RefCell, pin::Pin, rc::Rc};
 use autocxx::c_uint;
 use cxx::let_cxx_string;
 
-use crate::{inner, model::Model, pin_ptr, sbmlcxx, sbo_term, upcast_annotation};
+use crate::{inner, into_id, model::Model, pin_ptr, sbmlcxx, sbo_term, upcast_annotation};
 
 /// A safe wrapper around the libSBML Compartment class.
 ///
@@ -29,6 +29,9 @@ inner!(sbmlcxx::Compartment, Compartment<'a>);
 
 // Set the annotation trait for the Compartment struct
 upcast_annotation!(Compartment<'a>, sbmlcxx::Compartment, sbmlcxx::SBase);
+
+// Set the into_id trait for the Compartment struct
+into_id!(&Rc<Compartment<'_>>, id);
 
 impl<'a> Compartment<'a> {
     /// Creates a new Compartment instance within the given Model.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod traits {
     pub mod annotation;
     pub mod fromptr;
     pub mod inner;
+    pub mod intoid;
 }
 
 /// Module providing upcast functionality
@@ -77,6 +78,7 @@ pub mod prelude {
     pub use crate::species::*;
     pub use crate::speciesref::*;
     pub use crate::traits::annotation::*;
+    pub use crate::traits::intoid::*;
     pub use crate::unit::*;
     pub use crate::unitdef::*;
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -253,3 +253,14 @@ macro_rules! sbo_term {
         }
     };
 }
+
+#[macro_export]
+macro_rules! into_id {
+    ($type:ty, $property:ident) => {
+        impl<'a> crate::traits::intoid::IntoId<'a> for $type {
+            fn into_id(self) -> &'a str {
+                Box::leak(self.$property().into_boxed_str())
+            }
+        }
+    };
+}

--- a/src/modref.rs
+++ b/src/modref.rs
@@ -10,7 +10,8 @@
 use std::{cell::RefCell, pin::Pin};
 
 use crate::{
-    inner, pin_ptr, reaction::Reaction, sbmlcxx, sbo_term, upcast, upcast_annotation, upcast_pin,
+    inner, pin_ptr, prelude::IntoId, reaction::Reaction, sbmlcxx, sbo_term, upcast,
+    upcast_annotation, upcast_pin,
 };
 use cxx::let_cxx_string;
 
@@ -115,8 +116,8 @@ impl<'a> ModifierSpeciesReferenceBuilder<'a> {
     ///
     /// # Returns
     /// A new ModifierSpeciesReferenceBuilder instance
-    pub fn new(reaction: &Reaction<'a>, sid: &str) -> Self {
-        let modifier_reference = ModifierSpeciesReference::new(reaction, sid);
+    pub fn new(reaction: &Reaction<'a>, sid: impl IntoId<'a>) -> Self {
+        let modifier_reference = ModifierSpeciesReference::new(reaction, sid.into_id());
         Self { modifier_reference }
     }
 

--- a/src/parameter.rs
+++ b/src/parameter.rs
@@ -13,7 +13,7 @@ use std::{cell::RefCell, pin::Pin, rc::Rc};
 use cxx::let_cxx_string;
 
 use crate::{
-    inner,
+    inner, into_id,
     model::Model,
     pin_ptr,
     sbmlcxx::{self},
@@ -35,6 +35,9 @@ inner!(sbmlcxx::Parameter, Parameter<'a>);
 
 // Set the annotation trait for the Parameter struct
 upcast_annotation!(Parameter<'a>, sbmlcxx::Parameter, sbmlcxx::SBase);
+
+// Set the into_id trait for the Compartment struct
+into_id!(&Rc<Parameter<'_>>, id);
 
 impl<'a> Parameter<'a> {
     /// Creates a new Parameter instance within the given Model.

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -13,10 +13,11 @@ use std::{cell::RefCell, pin::Pin, rc::Rc};
 use cxx::let_cxx_string;
 
 use crate::{
-    inner,
+    inner, into_id,
     model::Model,
     modref::{ModifierSpeciesReference, ModifierSpeciesReferenceBuilder},
     pin_ptr,
+    prelude::IntoId,
     sbmlcxx::{self},
     sbo_term,
     speciesref::{SpeciesReference, SpeciesReferenceBuilder, SpeciesReferenceType},
@@ -41,6 +42,9 @@ inner!(sbmlcxx::Reaction, Reaction<'a>);
 
 // Set the annotation trait for the Reaction struct
 upcast_annotation!(Reaction<'a>, sbmlcxx::Reaction, sbmlcxx::SBase);
+
+// Set the into_id trait for the Reaction struct
+into_id!(&Rc<Reaction<'_>>, id);
 
 impl<'a> Reaction<'a> {
     /// Creates a new Reaction instance within the given Model.
@@ -116,7 +120,11 @@ impl<'a> Reaction<'a> {
     ///
     /// # Returns
     /// A reference-counted pointer to the new SpeciesReference
-    pub fn create_product(&self, sid: &str, stoichiometry: f64) -> Rc<SpeciesReference<'a>> {
+    pub fn create_product(
+        &self,
+        sid: impl IntoId<'a>,
+        stoichiometry: f64,
+    ) -> Rc<SpeciesReference<'a>> {
         let product = Rc::new(SpeciesReference::new(
             self,
             sid,
@@ -134,7 +142,7 @@ impl<'a> Reaction<'a> {
     ///
     /// # Returns
     /// A SpeciesReferenceBuilder for configuring and creating the product
-    pub fn build_product(&self, sid: &str) -> SpeciesReferenceBuilder<'a> {
+    pub fn build_product(&self, sid: impl IntoId<'a>) -> SpeciesReferenceBuilder<'a> {
         SpeciesReferenceBuilder::new(&self, sid, SpeciesReferenceType::Product)
     }
 
@@ -169,7 +177,11 @@ impl<'a> Reaction<'a> {
     ///
     /// # Returns
     /// A reference-counted pointer to the new SpeciesReference
-    pub fn create_reactant(&self, sid: &str, stoichiometry: f64) -> Rc<SpeciesReference<'a>> {
+    pub fn create_reactant(
+        &self,
+        sid: impl IntoId<'a>,
+        stoichiometry: f64,
+    ) -> Rc<SpeciesReference<'a>> {
         let reactant = Rc::new(SpeciesReference::new(
             self,
             sid,
@@ -187,7 +199,7 @@ impl<'a> Reaction<'a> {
     ///
     /// # Returns
     /// A SpeciesReferenceBuilder for configuring and creating the reactant
-    pub fn build_reactant(&self, sid: &str) -> SpeciesReferenceBuilder<'a> {
+    pub fn build_reactant(&self, sid: impl IntoId<'a>) -> SpeciesReferenceBuilder<'a> {
         SpeciesReferenceBuilder::new(&self, sid, SpeciesReferenceType::Reactant)
     }
 
@@ -234,7 +246,7 @@ impl<'a> Reaction<'a> {
     ///
     /// # Returns
     /// A ModifierSpeciesReferenceBuilder for configuring and creating the modifier
-    pub fn build_modifier(&self, sid: &str) -> ModifierSpeciesReferenceBuilder<'a> {
+    pub fn build_modifier(&self, sid: impl IntoId<'a>) -> ModifierSpeciesReferenceBuilder<'a> {
         ModifierSpeciesReferenceBuilder::new(&self, sid)
     }
     /// Returns a reference to the modifiers of this reaction.
@@ -324,8 +336,8 @@ impl<'a> ReactionBuilder<'a> {
     ///
     /// # Returns
     /// The builder instance for method chaining
-    pub fn product(self, sid: &str, stoichiometry: f64) -> Self {
-        self.reaction.create_product(sid, stoichiometry);
+    pub fn product(self, sid: impl IntoId<'a>, stoichiometry: f64) -> Self {
+        self.reaction.create_product(sid.into_id(), stoichiometry);
         self
     }
 
@@ -337,8 +349,8 @@ impl<'a> ReactionBuilder<'a> {
     ///
     /// # Returns
     /// The builder instance for method chaining
-    pub fn reactant(self, sid: &str, stoichiometry: f64) -> Self {
-        self.reaction.create_reactant(sid, stoichiometry);
+    pub fn reactant(self, sid: impl IntoId<'a>, stoichiometry: f64) -> Self {
+        self.reaction.create_reactant(sid.into_id(), stoichiometry);
         self
     }
 
@@ -349,10 +361,11 @@ impl<'a> ReactionBuilder<'a> {
     ///
     /// # Returns
     /// The builder instance for method chaining
-    pub fn modifier(self, sid: &str) -> Self {
-        self.reaction.create_modifier(sid);
+    pub fn modifier(self, sid: impl IntoId<'a>) -> Self {
+        self.reaction.create_modifier(sid.into_id());
         self
     }
+
     pub fn build(self) -> Rc<Reaction<'a>> {
         self.reaction
     }

--- a/src/species.rs
+++ b/src/species.rs
@@ -13,9 +13,10 @@ use std::{cell::RefCell, pin::Pin, rc::Rc};
 use cxx::let_cxx_string;
 
 use crate::{
-    inner,
+    inner, into_id,
     model::Model,
     pin_ptr,
+    prelude::IntoId,
     sbmlcxx::{self},
     sbo_term,
     traits::fromptr::FromPtr,
@@ -35,6 +36,9 @@ inner!(sbmlcxx::Species, Species<'a>);
 
 // Set the annotation trait for the Species struct
 upcast_annotation!(Species<'a>, sbmlcxx::Species, sbmlcxx::SBase);
+
+// Set the into_id trait for the Species struct
+into_id!(&Rc<Species<'_>>, id);
 
 impl<'a> Species<'a> {
     /// Creates a new Species instance within the given Model.
@@ -120,7 +124,8 @@ impl<'a> Species<'a> {
     ///
     /// # Arguments
     /// * `compartment` - The identifier of the compartment
-    pub fn set_compartment(&self, compartment: &str) {
+    pub fn set_compartment(&self, compartment: impl IntoId<'a>) {
+        let compartment = compartment.into_id();
         let_cxx_string!(compartment = compartment);
         self.inner
             .borrow_mut()
@@ -311,7 +316,7 @@ impl<'a> SpeciesBuilder<'a> {
     ///
     /// # Arguments
     /// * `compartment` - The compartment identifier
-    pub fn compartment(self, compartment: &str) -> Self {
+    pub fn compartment(self, compartment: impl IntoId<'a>) -> Self {
         self.species.set_compartment(compartment);
         self
     }

--- a/src/traits/intoid.rs
+++ b/src/traits/intoid.rs
@@ -1,0 +1,86 @@
+//! Trait for converting strings into string references with appropriate lifetimes
+//!
+//! This module provides functionality to convert owned Strings and string slices
+//! into string references with proper lifetime management. This is useful
+//! when working with APIs that require string references.
+//!
+//! # Examples
+//! ```
+//! use sbml::traits::intoid::IntoId;
+//!
+//! let owned = String::from("species1");
+//! let str_ref = owned.into_id(); // Borrows from owned
+//!
+//! let slice = "species2";
+//! let str_ref = slice.into_id(); // Simply returns the slice
+//! ```
+
+/// Trait for converting a type into a string reference with appropriate lifetime
+///
+/// This trait provides a way to convert strings into references with proper
+/// lifetime management instead of leaking memory.
+pub trait IntoId<'a> {
+    /// Converts self into a string reference with appropriate lifetime
+    fn into_id(self) -> &'a str;
+}
+
+impl<'a> IntoId<'a> for &'a String {
+    /// Converts a reference to String into a string slice
+    fn into_id(self) -> &'a str {
+        self.as_str()
+    }
+}
+
+impl<'a> IntoId<'a> for &'a str {
+    /// Simply returns the string slice with its existing lifetime
+    fn into_id(self) -> &'a str {
+        self
+    }
+}
+
+// Optional: Implementation for owned String that returns a reference to a newly created String
+// Note: This requires the caller to maintain the String while using the reference
+impl<'a> IntoId<'a> for &'a mut String {
+    fn into_id(self) -> &'a str {
+        self.as_str()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::into_id;
+
+    use super::*;
+
+    #[test]
+    fn test_into_id() {
+        // Test with a String reference
+        let owned = String::from("species1");
+        let str_ref = (&owned).into_id();
+        assert_eq!(str_ref, "species1");
+
+        // Test with a string slice
+        let slice = "species2";
+        let str_ref = slice.into_id();
+        assert_eq!(str_ref, "species2");
+
+        // Test with a struct
+        struct TestStruct {
+            id: String,
+        }
+
+        impl TestStruct {
+            fn id(&self) -> String {
+                self.id.clone()
+            }
+        }
+
+        into_id!(TestStruct, id);
+
+        let test_struct = TestStruct {
+            id: String::from("species3"),
+        };
+        let str_ref = test_struct.id();
+        assert_eq!(str_ref, "species3");
+    }
+}


### PR DESCRIPTION
This PR introduces a QoL improvement trait called `IntoID`, which provides a standardized interface to extract relevant IDs for re-use in other parts of the code. The implementation now allows `imp IntoId<...>` types to either accept a raw ID string or a struct that has implemented the trait.

**Example**

```rust
// Create a compartment
    let compartment = model
        .build_compartment("cytosol")
        .name("cytosol")
        .unit(&ml.id())
        .build();

    // Create the ethanol species
    let ethanol = model
        .build_species("ethanol")
        .name("Ethanol")
        .compartment(&compartment) // We can now pass the entire instance or `compartment.id()`
        .initial_concentration(0.5)
        .unit(&mole.id())
        .has_only_substance_units(false)
        .build();
```